### PR TITLE
Create proper domain name from bitbucket team name 

### DIFF
--- a/madcore/configure.py
+++ b/madcore/configure.py
@@ -11,6 +11,7 @@ import botocore.exceptions
 from cliff.command import Command
 
 from madcore import const
+from madcore import utils
 from madcore.base import CloudFormationBase
 from madcore.configs import config
 from madcore.libs.aws import AwsLambda, AwsConfig
@@ -332,7 +333,11 @@ class MadcoreConfigure(CloudFormationBase, Command):
                 selected_domain = self.single_prompt('domain', options=self.get_allowed_domains(),
                                                      prompt='Select madcore domain')
 
-                user_sub_domain = '{team}.{domain}'.format(team=selected_team['team'], domain=selected_domain['domain'])
+                team_name = utils.str_to_domain_name(selected_team['team'])
+                if team_name != selected_team['team']:
+                    self.logger.info("Team name was converted into proper domain name: '%s'", team_name)
+
+                user_sub_domain = '{team_name}.{domain}'.format(team_name=team_name, domain=selected_domain['domain'])
 
                 self.logger.info("The following domain will be configured: '%s'", user_sub_domain)
 
@@ -343,7 +348,7 @@ class MadcoreConfigure(CloudFormationBase, Command):
 
                     user_data.update({
                         'domain': selected_domain['domain'],
-                        'sub_domain': selected_team['team'],
+                        'sub_domain': team_name,
                         'created': True
                     })
                     # at this point we save data into config because we know that user already created on madcore part

--- a/madcore/utils.py
+++ b/madcore/utils.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, print_function
 
 import os
+import re
 import socket
 import time
 
@@ -50,3 +51,17 @@ def hostname_resolves(hostname, max_time=700):
 def get_version():
     dist = pkg_resources.get_distribution("madcore")
     return dist.version
+
+
+def str_to_domain_name(string):
+    """
+    Convert a string into a proper domain name: RFC 1034 standard
+
+    :param str string: Input string to convert
+    :return: str
+    """
+
+    if not string:
+        return string
+
+    return '-'.join(filter(None, re.sub(r'[\W+_]', '-', string).split('-')))


### PR DESCRIPTION
Fixed #66. Currently we replace any non alphanumeric char into '-'. 

```
_geo--mad_-core_ -> geo-mad-core
```