### PR TITLE
plugin install INGRESS extension

### DIFF
--- a/madcore/base.py
+++ b/madcore/base.py
@@ -879,17 +879,18 @@ class PluginsBase(CloudFormationBase):
     PLUGIN_DEFAULT_JOBS = ['deploy', 'delete', 'status']
     PLUGIN_TYPES = [const.PLUGIN_TYPE_PLUGIN, const.PLUGIN_TYPE_CLUSTER]
 
-    def update_core_params(self, new_params, param_prefix, add_madcore_prefix=True, prefix_to_upper=True,
+    def update_core_params(self, new_params, param_prefix=None, add_madcore_prefix=True, prefix_to_upper=True,
                            param_to_upper=False):
         key_format = []
 
         if add_madcore_prefix:
             key_format.append('MADCORE')
 
-        if prefix_to_upper:
+        if prefix_to_upper and param_prefix:
             param_prefix = param_prefix.upper()
 
-        key_format.append(param_prefix)
+        if param_prefix:
+            key_format.append(param_prefix)
 
         prefix = '_'.join(key_format)
 

--- a/madcore/const.py
+++ b/madcore/const.py
@@ -64,3 +64,5 @@ REPO_CLONE = [
     'cloudformation',
     'containers'
 ]
+
+PLUGIN_NAME_INGRESS = 'ingress'

--- a/madcore/libs/plugins.py
+++ b/madcore/libs/plugins.py
@@ -183,6 +183,8 @@ class PluginManagement(JenkinsBase, StackManagement):
         return stack_details
 
     def execute_plugin_job(self, plugin_name, current_job_name, parsed_args):
+        self.update_core_params({'ingress_flag': getattr(parsed_args, 'ingress_flag', False)}, param_to_upper=True)
+
         job_definition = self.get_plugin_job_definition(plugin_name, current_job_name)
 
         CF_ACTIONS = {


### PR DESCRIPTION
Added `--ingress` option when installing plugins. This option will be available in global vars via `MADCORE_PLUGIN_FLAG` so that we can use it in plugins index definition.