### PR TITLE
Scrapy cluster rc 1.2

### DIFF
--- a/madcore/templates/kubectl.9400.scrapy-cluster-configmap-rc.yaml
+++ b/madcore/templates/kubectl.9400.scrapy-cluster-configmap-rc.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scrapy-rc-configmap
+  namespace: scrapy-rc
+data:
+    SLEEP_TIME: "0.1"
+    HEARTBEAT_TIMEOUT: "120"
+    
+    # REDIS
+    REDIS_HOST: "redis.scrapy-rc"
+    REDIS_PORT: "6379"
+    REDIS_DB: "0"
+
+    # KAFKA-MONITOR: KAFKA
+    KAFKA_HOSTS: "broker.kafka:9092"
+    KAFKA_INCOMING_TOPIC: "demo.incoming"
+    KAFKA_GROUP: "10"
+    KAFKA_FEED_TIMEOUT: "latest"
+    KAFKA_CONSUMER_AUTO_OFFSET_RESET: "50"
+    KAFKA_CONSUMER_TIMEOUT: "5000"
+    KAFKA_CONSUMER_COMMIT_INTERVAL_MS: "True"
+    KAFKA_CONSUMER_AUTO_COMMIT_ENABLE: "10 * 1024 * 1024"
+    KAFKA_CONSUMER_FETCH_MESSAGE_MAX_BYTES: "1"
+    KAFKA_PRODUCER_BATCH_LINGER_MS: "25"
+    KAFKA_PRODUCER_BUFFER_BYTES: "4 * 1024 * 1024"
+
+    # CRAWLER: ZOOKEEPER
+    ZOOKEEPER_ASSIGN_PATH: "/scrapy-cluster/crawler/"
+    ZOOKEEPER_ID: "all"
+    ZOOKEEPER_HOSTS: "pzoo.kafka:2181"
+
+
+    # KAFKA-MONITOR: PLUGINS
+    PLUGIN_DIR: "plugins/"
+    PLUGINS: |-
+        {
+            'plugins.scraper_handler.ScraperHandler': 100,
+            'plugins.action_handler.ActionHandler': 200,
+            'plugins.stats_handler.StatsHandler': 300,
+            'plugins.zookeeper_handler.ZookeeperHandler': 400,
+        }
+
+    # KAFKA-MONITOR: LOGGING
+    LOGGER_NAME: "kafka-monitor"
+    LOG_DIR: "logs"
+    LOG_FILE: "kafka_monitor.log"
+    LOG_MAX_BYTES: "10 * 1024 * 1024"
+    LOG_BACKUPS: "5"
+    LOG_STDOUT: "True"
+    LOG_JSON: "False"
+    LOG_LEVEL: "DEBUG"
+
+    # KAFKA-MONITOR: STATS
+    STATS_TOTAL: "True"
+    STATS_PLUGINS: "True"
+    STATS_CYCLE: "5"
+    STATS_DUMP: "60"
+    STATS_TIMES: |-
+        [
+            'SECONDS_15_MINUTE',
+            'SECONDS_1_HOUR',
+            'SECONDS_6_HOUR',
+            'SECONDS_12_HOUR',
+            'SECONDS_1_DAY',
+            'SECONDS_1_WEEK',
+        ]

--- a/madcore/templates/kubectl.9401.scrapy-cluster-ns-rc.yaml
+++ b/madcore/templates/kubectl.9401.scrapy-cluster-ns-rc.yaml
@@ -1,0 +1,6 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: scrapy-rc
+  labels:
+    name: scrapy-rc

--- a/madcore/templates/kubectl.9402.scrapy-cluster-redis-rc.yaml
+++ b/madcore/templates/kubectl.9402.scrapy-cluster-redis-rc.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: scrapy-rc
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis
+        ports:
+        - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: scrapy-rc
+  labels:
+    app: redis
+spec:
+  ports:
+  - name: redis
+    port: 6379
+  selector:
+    app: redis
+

--- a/madcore/templates/kubectl.9403.scrapy-cluster-zookeeper-rc.yaml
+++ b/madcore/templates/kubectl.9403.scrapy-cluster-zookeeper-rc.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+  namespace: scrapy-rc
+  labels:
+    app: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+      - name: zookeeper
+        image: zookeeper
+        ports:
+        - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: scrapy-rc
+  labels:
+    app: zookeeper
+spec:
+  ports:
+  - name: zookeeper
+    port: 2181
+  selector:
+    app: zookeeper
+

--- a/madcore/templates/kubectl.9404.scrapy-cluster-kafka-rc.yaml
+++ b/madcore/templates/kubectl.9404.scrapy-cluster-kafka-rc.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: scrapy-rc
+  labels:
+    app: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+      - name: kafka
+        image: wurstmeister/kafka
+        ports:
+        - containerPort: 9092
+        env:
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: "zookeeper.scrapy-rc:2181"
+        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+          value: "1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: scrapy-rc
+  labels:
+    app: kafka
+spec:
+  ports:
+  - name: kafka
+    port: 9092
+  selector:
+    app: kafka
+

--- a/madcore/templates/kubectl.9405.scrapy-cluster-kafka-monitor-rc.yaml
+++ b/madcore/templates/kubectl.9405.scrapy-cluster-kafka-monitor-rc.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-monitor-rc
+  namespace: scrapy-rc
+  labels:
+    app: kafka-monitor-rc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-monitor-rc
+  template:
+    metadata:
+      labels:
+        app: kafka-monitor-rc
+    spec:
+      containers:
+      - name: kafka-monitor-rc
+        image: istresearch/scrapy-cluster:kafka-monitor-1.2
+        envFrom:
+        - configMapRef:
+            name: 'scrapy-rc-configmap'

--- a/madcore/templates/kubectl.9406.scrapy-cluster-rest-rc.yaml
+++ b/madcore/templates/kubectl.9406.scrapy-cluster-rest-rc.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rest-rc
+  namespace: scrapy-rc
+  labels:
+    app: rest-rc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rest-rc
+  template:
+    metadata:
+      labels:
+        app: rest-rc
+    spec:
+      containers:
+      - name: rest-rc
+        image: istresearch/scrapy-cluster:rest-1.2
+        ports:
+        - containerPort: 5343
+        env:
+        # REST SETTINGS: http://scrapy-cluster.readthedocs.io/en/latest/topics/rest/settings.html
+        # REST: CORE
+        - name: FLASK_LOGGING_ENABLED
+          value: "True"
+        - name: FLASK_PORT
+          value: "5343"
+        - name: SLEEP_TIME
+          value: "0.1"
+        - name: HEARTBEAT_TIMEOUT
+          value: "120"
+        - name: DAEMON_THREAD_JOIN_TIMEOUT
+          value: "10"
+        - name: WAIT_FOR_RESPONSE_TIME
+          value: "5"
+        - name: SCHEMA_DIR
+          value: "schemas/"
+
+
+        # REST: REDIS
+        - name: REDIS_HOST
+          value: "redis.scrapy"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "0"
+
+
+        # REST: KAFKA
+        - name: KAFKA_HOSTS
+          value: "broker.kafka:9092"
+        - name: KAFKA_TOPIC_PREFIX
+          value: "demo"
+        - name: KAFKA_FEED_TIMEOUT
+          value: "10"
+        - name: KAFKA_CONSUMER_AUTO_OFFSET_RESET
+          value: "latest"
+        - name: KAFKA_CONSUMER_TIMEOUT
+          value: "50"
+        - name: KAFKA_CONSUMER_COMMIT_INTERVAL_MS
+          value: "5000"
+        - name: KAFKA_CONSUMER_AUTO_COMMIT_ENABLE
+          value: "True"
+        - name: KAFKA_CONSUMER_FETCH_MESSAGE_MAX_BYTES
+          value: "10 * 1024 * 1024"
+        - name: KAFKA_CONSUMER_SLEEP_TIME
+          value: "1"
+        - name: KAFKA_PRODUCER_TOPIC
+          value: "demo.incoming"
+        - name: KAFKA_PRODUCER_BATCH_LINGER_MS
+          value: "25"
+        - name: KAFKA_PRODUCER_BUFFER_BYTES
+          value: "4 * 1024 * 1024"
+
+
+        # CRAWLER: LOGGING
+        - name: LOGGER_NAME
+          value: "rest-service"
+        - name: LOG_DIR
+          value: "logs"
+        - name: LOG_FILE
+          value: "rest_service.log"
+        - name: LOG_MAX_BYTES
+          value: "10 * 1024 * 1024"
+        - name: LOG_BACKUPS
+          value: "5"
+        - name: LOG_STDOUT
+          value: "True"
+        - name: LOG_JSON
+          value: "False"
+        - name: LOG_LEVEL
+          value: "INFO"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rest-rc
+  namespace: scrapy-rc
+  labels:
+    app: rest-rc
+spec:
+  ports:
+  - name: rest-rc
+    port: 5343
+  selector:
+    app: rest-rc
+

--- a/madcore/templates/kubectl.9407.scrapy-cluster-crawler-rc.yaml
+++ b/madcore/templates/kubectl.9407.scrapy-cluster-crawler-rc.yaml
@@ -1,0 +1,129 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crawler
+  namespace: scrapy-rc
+  labels:
+    app: crawler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: crawler
+  template:
+    metadata:
+      labels:
+        app: crawler
+    spec:
+      containers:
+      - name: crawler
+        image: istresearch/scrapy-cluster:crawler-1.2
+        # envFrom:
+        # - configMapRef:
+            # name: 'scrapy-rc-configmap'
+        env:
+        # CRAWLER SETTINGS: http://scrapy-cluster.readthedocs.io/en/latest/topics/crawler/settings.html
+        # CRAWLER: REDIS
+        - name: REDIS_HOST
+          value: "redis.scrapy-rc"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "0"
+
+        # CRAWLER: KAFKA
+        - name: KAFKA_HOSTS
+          value: "broker.kafka:9092"
+        - name: KAFKA_TOPIC_PREFIX
+          value: "demo"
+        - name: KAFKA_APPID_TOPICS
+          value: "False"
+        - name: KAFKA_BASE_64_ENCODE
+          value: "False"
+        - name: KAFKA_PRODUCER_BATCH_LINGER_MS
+          value: "25"
+        - name: KAFKA_PRODUCER_BUFFER_BYTES
+          value: "4 * 1024 * 1024"
+
+        # CRAWLER: ZOOKEEPER
+        - name: ZOOKEEPER_ASSIGN_PATH
+          value: "/scrapy-cluster/crawler/"
+        - name: ZOOKEEPER_ID
+          value: "all"
+        - name: ZOOKEEPER_HOSTS
+          value: "pzoo.kafka:2181"
+
+        # CRAWLER: SCHEDULER
+        - name: SCHEDULER_PERSIST
+          value: "True"
+        - name: SCHEDULER_QUEUE_REFRESH
+          value: "10"
+        - name: SCHEDULER_QUEUE_TIMEOUT
+          value: "3600"
+        - name: SCHEDULER_BACKLOG_BLACKLIST
+          value: "True"
+
+        # CRAWLER: THROTTLE
+        - name: QUEUE_HITS
+          value: "10"
+        - name: QUEUE_WINDOW
+          value: "60"
+        - name: QUEUE_MODERATED
+          value: "True"
+        - name: DUPEFILTER_TIMEOUT
+          value: "600"
+        - name: SCHEDULER_IP_REFRESH
+          value: "60"
+        - name: PUBLIC_IP_URL
+          value: "http://ip.42.pl/raw"
+        - name: IP_ADDR_REGEX
+          value: (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
+        - name: SCHEDULER_TYPE_ENABLED
+          value: "True"
+        - name: SCHEDULER_IP_ENABLED
+          value: "True"
+        - name: SCHEUDLER_ITEM_RETRIES
+          value: "2"
+
+        # CRAWLER: LOGGING
+        - name: SC_LOGGER_NAME
+          value: "sc-crawler"
+        - name: SC_LOG_DIR
+          value: "logs"
+        - name: SC_LOG_FILE
+          value: "sc_crawler.log"
+        - name: SC_LOG_MAX_BYTES
+          value: "10 * 1024 * 1024"
+        - name: SC_LOG_BACKUPS
+          value: "5"
+        - name: SC_LOG_STDOUT
+          value: "True"
+        - name: SC_LOG_JSON
+          value: "False"
+        - name: SC_LOG_LEVEL
+          value: "INFO"
+
+        # CRAWLER: STATS
+        - name: STATS_STATUS_CODES
+          value: "True"
+        - name: STATUS_RESPONSE_CODES
+          value: |-
+            [
+                200,
+                404,
+                403,
+                504,
+            ]
+        - name: STATS_CYCLE
+          value: "5"
+        - name: STATS_TIMES
+          value: |-
+            [
+                'SECONDS_15_MINUTE',
+                'SECONDS_1_HOUR',
+                'SECONDS_6_HOUR',
+                'SECONDS_12_HOUR',
+                'SECONDS_1_DAY',
+                'SECONDS_1_WEEK',
+            ]

--- a/madcore/templates/kubectl.9408.scrapy-cluster-redis-monitor-rc.yaml
+++ b/madcore/templates/kubectl.9408.scrapy-cluster-redis-monitor-rc.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-monitor
+  namespace: scrapy-rc
+  labels:
+    app: redis-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-monitor
+  template:
+    metadata:
+      labels:
+        app: redis-monitor
+    spec:
+      containers:
+      - name: redis-monitor
+        image: istresearch/scrapy-cluster:redis-monitor-1.2
+        # envFrom:
+        # - configMapRef:
+        #     name: 'scrapy-rc-configmap'
+        env:
+        # Redis-MONITOR SETTINGS: http://scrapy-cluster.readthedocs.io/en/latest/topics/redis-monitor/settings.html
+        # Redis-MONITOR: CORE
+        #REDIS
+        - name: REDIS_HOST
+          value: "redis.scrapy-rc"
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "0"
+
+        #KAFKA
+        - name: KAFKA_HOSTS
+          value: "broker.kafka:9092"
+        - name: KAFKA_TOPIC_PREFIX
+          value: "demo"
+        - name: KAFKA_APPID_TOPICS
+          value: "False"
+        - name: KAFKA_BASE_64_ENCODE
+          value: "False"
+        - name: KAFKA_PRODUCER_BATCH_LINGER_MS
+          value: "25"
+        - name: KAFKA_PRODUCER_BUFFER_BYTES
+          value: "4 * 1024 * 1024"
+
+        #ZOOKEEPER
+        - name: ZOOKEEPER_ASSIGN_PATH
+          value: "/scrapy-cluster/crawler/"
+        - name: ZOOKEEPER_ID
+          value: "all"
+        - name: ZOOKEEPER_HOSTS
+          value: "pzoo.kafka:2181"
+
+        #SCHEDULER
+        - name: SCHEDULER_PERSIST
+          value: "True"
+        - name: SCHEDULER_QUEUE_REFRESH
+          value: "10"
+        - name: SCHEDULER_QUEUE_TIMEOUT
+          value: "3600"
+        - name: SCHEDULER_BACKLOG_BLACKLIST
+          value: "True"
+
+        #THROTTLE
+        - name: QUEUE_HITS
+          value: "10"
+        - name: QUEUE_WINDOW
+          value: "60"
+        - name: QUEUE_MODERATED
+          value: "True"
+        - name: DUPEFILTER_TIMEOUT
+          value: "600"
+        - name: SCHEDULER_IP_REFRESH
+          value: "60"
+        - name: PUBLIC_IP_URL
+          value: "http://ip.42.pl/raw"
+        - name: IP_ADDR_REGEX
+          value: (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
+        - name: SCHEDULER_TYPE_ENABLED
+          value: "True"
+        - name: SCHEDULER_IP_ENABLED
+          value: "True"
+        - name: SCHEUDLER_ITEM_RETRIES
+          value: "2"
+
+        #LOGGING
+        - name: SC_LOGGER_NAME
+          value: "sc-crawler"
+        - name: SC_LOG_DIR
+          value: "logs"
+        - name: SC_LOG_FILE
+          value: "sc_crawler.log"
+        - name: SC_LOG_MAX_BYTES
+          value: "10 * 1024 * 1024"
+        - name: SC_LOG_BACKUPS
+          value: "5"
+        - name: SC_LOG_STDOUT
+          value: "True"
+        - name: SC_LOG_JSON
+          value: "False"
+        - name: SC_LOG_LEVEL
+          value: "INFO"
+
+        #STATS
+        - name: STATS_STATUS_CODES
+          value: "True"
+        - name: STATUS_RESPONSE_CODES
+          value: |-
+            [
+                200,
+                404,
+                403,
+                504,
+            ]
+        - name: STATS_CYCLE
+          value: "5"
+        - name: STATS_TIMES
+          value: |-
+            [
+                'SECONDS_15_MINUTE',
+                'SECONDS_1_HOUR',
+                'SECONDS_6_HOUR',
+                'SECONDS_12_HOUR',
+                'SECONDS_1_DAY',
+                'SECONDS_1_WEEK',
+            ]


### PR DESCRIPTION
Setup Scrapy cluster rc1.2, template files 9400-9408

Must run `madcode --install-kafka` before installing cluster.  

Kafka (9404) and Zookeeper (9403) files are placeholders if we want to have multiple Kafka hosts, then a few modifications will be required. 

More config map work could be done, but the basic running setup is there.

